### PR TITLE
feat: use passwordHash for authentication

### DIFF
--- a/prisma prisma/schema.prisma
+++ b/prisma prisma/schema.prisma
@@ -2,7 +2,7 @@ model User {
   id         Int      @id @default(autoincrement())
   email      String   @unique
   username   String?  @unique
-  password   String
+  passwordHash String
   name       String?
   bio        String?
   gender     String?

--- a/prisma/migrations/20250906120000_use-passwordHash-field/migration.sql
+++ b/prisma/migrations/20250906120000_use-passwordHash-field/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "User" DROP COLUMN IF EXISTS "password";
+ALTER TABLE "User" ALTER COLUMN "passwordHash" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,7 +11,7 @@ model User {
   id         Int      @id @default(autoincrement())
   email      String   @unique
   username   String?  @unique
-  password   String
+  passwordHash String
   name       String?
   bio        String?
   gender     String?

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -22,7 +22,7 @@ async function main() {
         birthdate,
         bio: faker.lorem.sentence(),
         avatarUrl: faker.image.avatar(),
-        password: passwordHash,
+        passwordHash,
       },
     });
     users.push(user);

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -30,12 +30,12 @@ export async function POST(req: Request) {
       );
     }
     const { name, username, email, password } = parsed.data;
-    const hashed = await bcrypt.hash(password, 10);
+    const passwordHash = await bcrypt.hash(password, 10);
     const user = await prisma.user.create({
-      data: { name, username, email, password: hashed },
+      data: { name, username, email, passwordHash },
       select: { id: true, email: true, username: true, name: true },
     });
-    return NextResponse.json({ user }, { status: 201 });
+    return NextResponse.json(user, { status: 201 });
   } catch (err: any) {
     if (err?.code === "P2002") {
       log("POST /api/auth/register: duplicate", err);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -27,8 +27,8 @@ export const authOptions: NextAuthOptions = {
             ? { email: identifier }
             : { username: identifier };
         const user = await prisma.user.findUnique({ where });
-        if (!user || !user.password) return null;
-        const valid = await bcrypt.compare(password, user.password);
+        if (!user || !user.passwordHash) return null;
+        const valid = await bcrypt.compare(password, user.passwordHash);
         if (!valid) return null;
         return {
           id: user.id,


### PR DESCRIPTION
## Summary
- use `passwordHash` field in Prisma schema and drop legacy `password`
- hash passwords on register and verify with credentials provider
- seed demo users with hashed passwords

## Testing
- ⚠️ `pnpm lint` *(failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz)*
- ⚠️ `pnpm typecheck` *(failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz)*
- ⚠️ `pnpm prisma generate` *(failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz)*
- ⚠️ `pnpm prisma migrate dev -n "use-passwordHash-field"` *(failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz)*
- ⚠️ `pnpm prisma db seed` *(failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz)*
- ⚠️ `pnpm dev` *(failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0e70d62883308bce4d84655891de