### PR TITLE
fix: configure allowed external image hosts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,24 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: { serverActions: { allowedOrigins: ['*'] } }
+  experimental: { serverActions: { allowedOrigins: ['*'] } },
+  images: {
+    domains: [
+      'cdn.jsdelivr.net',
+      'images.unsplash.com',
+      'lh3.googleusercontent.com',
+      'randomuser.me',
+      'res.cloudinary.com',
+      'picsum.photos',
+    ],
+    remotePatterns: [
+      { protocol: 'https', hostname: 'cdn.jsdelivr.net', pathname: '/gh/**' },
+      { protocol: 'https', hostname: 'images.unsplash.com', pathname: '/**' },
+      { protocol: 'https', hostname: 'lh3.googleusercontent.com', pathname: '/**' },
+      { protocol: 'https', hostname: 'randomuser.me', pathname: '/**' },
+      { protocol: 'https', hostname: 'res.cloudinary.com', pathname: '/**' },
+      { protocol: 'https', hostname: 'picsum.photos', pathname: '/seed/**' },
+    ],
+  },
 };
 module.exports = nextConfig;

--- a/src/app/feed/FeedClient.tsx
+++ b/src/app/feed/FeedClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useRef } from "react";
 import TinderCard from "react-tinder-card";
 import Image from "next/image";
+import { safeImageProps } from "@/lib/imageSafe";
 
 type UserCard = {
   id: string;
@@ -97,7 +98,7 @@ export default function FeedClient() {
               <div className="w-32 h-32 mb-4 relative">
                 {card.image ? (
                   <Image
-                    src={card.image}
+                    {...safeImageProps(card.image)}
                     alt={card.name || "Avatar"}
                     fill
                     className="object-cover rounded-full"

--- a/src/lib/imageSafe.ts
+++ b/src/lib/imageSafe.ts
@@ -1,0 +1,22 @@
+const allowedHosts = new Set([
+  'cdn.jsdelivr.net',
+  'images.unsplash.com',
+  'lh3.googleusercontent.com',
+  'randomuser.me',
+  'res.cloudinary.com',
+  'picsum.photos',
+]);
+
+export function isAllowedHost(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return allowedHosts.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function safeImageProps(src: string) {
+  return isAllowedHost(src) ? { src } : { src, unoptimized: true };
+}
+


### PR DESCRIPTION
## Summary
- allow external image hosts and paths in Next.js config
- add image safety helpers and use them when rendering user avatars

## Testing
- `npm run lint`
- `npm run build` *(fails: Type error in src/lib/auth.ts unrelated to image config)*

------
https://chatgpt.com/codex/tasks/task_e_68bc73bc786c833099779cdeca2a02a9