### PR TITLE
Improve swipe feed layout and deck behavior

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -68,8 +68,14 @@ export default async function FeedPage() {
 
   return (
     <main className="min-h-screen bg-[#0b0f14]">
-      <section className="px-4 pt-6 pb-10 flex justify-center">
-        <SwipeDeck profiles={profiles} />
+      <header className="px-4 pt-4">
+        <h1 className="text-3xl font-bold">Moodmacth</h1>
+      </header>
+
+      <section className="px-4 pt-4 pb-8 flex justify-center">
+        <div className="w-full max-w-md">
+          <SwipeDeck profiles={profiles} />
+        </div>
       </section>
     </main>
   );

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,4 +1,3 @@
-"use client";
 import Image from "next/image";
 
 export type Profile = {
@@ -11,9 +10,10 @@ export type Profile = {
 
 export default function ProfileCard({ profile }: { profile: Profile }) {
   const photo = profile.photos?.[0] ?? "/placeholder.jpg";
+
   return (
-    <div className="w-full h-full rounded-2xl overflow-hidden bg-neutral-900/30 border border-white/10 shadow-2xl">
-      <div className="relative w-full h-3/4">
+    <div className="grid grid-rows-[1fr_auto] w-full h-full rounded-2xl overflow-hidden bg-neutral-900/40 border border-white/10 shadow-2xl">
+      <div className="relative">
         <Image
           src={photo}
           alt={profile.name}
@@ -22,8 +22,11 @@ export default function ProfileCard({ profile }: { profile: Profile }) {
           className="object-cover"
           priority
         />
+        <div className="absolute left-3 top-3 text-white/70 text-xs pointer-events-none z-20">© 2025 Moodmacth</div>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/50 to-transparent" />
       </div>
-      <div className="p-4 space-y-1">
+
+      <div className="p-4">
         <h3 className="text-xl font-semibold">
           {profile.name}, <span className="text-white/60">{profile.age}</span>
         </h3>

--- a/src/components/SwipeDeck.tsx
+++ b/src/components/SwipeDeck.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useMemo, useState } from "react";
+import { useMemo, useState, type CSSProperties } from "react";
 import { motion, useMotionValue, useTransform, AnimatePresence, useAnimationControls } from "framer-motion";
 import ProfileCard, { type Profile } from "./ProfileCard";
 
@@ -7,15 +7,40 @@ export default function SwipeDeck({ profiles }: { profiles: Profile[] }) {
   const [idx, setIdx] = useState(0);
   const visible = useMemo(() => profiles.slice(idx, idx + 3), [profiles, idx]);
 
-  // Motion values for the TOP card only
+  // KUNCI: tinggi deck tetap (≈78vh); kartu akan mengisi deck ini
+  return (
+    <div className="relative h-[78vh] w-full overflow-hidden">
+      <Controls setIdx={setIdx} count={profiles.length} />
+      <Stack visible={visible} onAdvance={() => setIdx((i) => Math.min(i + 1, profiles.length))} />
+    </div>
+  );
+}
+
+function Controls({ setIdx, count }: { setIdx: any; count: number }) {
+  return (
+    <div className="absolute z-[60] bottom-4 left-0 right-0 flex justify-center gap-4">
+      <button
+        onClick={() => setIdx((i: number) => Math.min(i + 1, count))}
+        className="px-4 py-2 rounded-full bg-white/10 border border-white/20"
+      >
+        Skip
+      </button>
+      <button
+        onClick={() => setIdx((i: number) => Math.min(i + 1, count))}
+        className="px-4 py-2 rounded-full bg-white text-black"
+      >
+        Like
+      </button>
+    </div>
+  );
+}
+
+function Stack({ visible, onAdvance }: { visible: Profile[]; onAdvance: () => void }) {
   const controls = useAnimationControls();
   const x = useMotionValue(0);
   const rotate = useTransform(x, [-220, 0, 220], [-15, 0, 15]);
-
-  const SWIPE_OFFSET = 120; // px
-  const SWIPE_POWER = 220; // offset + velocity factor
-
-  const next = () => setIdx((i) => Math.min(i + 1, profiles.length));
+  const SWIPE_OFFSET = 120;
+  const SWIPE_POWER = 220;
 
   async function forceSwipe(dir: 1 | -1) {
     await controls.start({
@@ -25,8 +50,7 @@ export default function SwipeDeck({ profiles }: { profiles: Profile[] }) {
       transition: { duration: 0.25 },
     });
     controls.set({ x: 0, rotate: 0, opacity: 1 });
-    x.set(0);
-    next();
+    onAdvance();
   }
 
   function onDragEnd(_: any, info: { offset: { x: number }; velocity: { x: number } }) {
@@ -34,72 +58,49 @@ export default function SwipeDeck({ profiles }: { profiles: Profile[] }) {
     if (power > SWIPE_POWER || Math.abs(info.offset.x) > SWIPE_OFFSET) {
       forceSwipe(info.offset.x > 0 ? 1 : -1);
     } else {
-      controls.start({
-        x: 0,
-        rotate: 0,
-        opacity: 1,
-        transition: { type: "spring", stiffness: 380, damping: 28 },
-      });
+      controls.start({ x: 0, rotate: 0, opacity: 1, transition: { type: "spring", stiffness: 380, damping: 28 } });
     }
   }
 
   return (
-    <div className="relative w-full max-w-md mx-auto h-[78vh] overflow-hidden">
-      {/* Optional buttons; remove if pure gesture */}
-      <div className="absolute z-[60] bottom-4 left-0 right-0 flex justify-center gap-4">
-        <button
-          onClick={() => forceSwipe(-1)}
-          className="px-4 py-2 rounded-full bg-white/10 border border-white/20"
-        >
-          Skip
-        </button>
-        <button
-          onClick={() => forceSwipe(1)}
-          className="px-4 py-2 rounded-full bg-white text-black"
-        >
-          Like
-        </button>
-      </div>
+    <div className="absolute inset-0">
+      {visible
+        .map((p, i) => ({ p, i })) // i: 0=top
+        .reverse() // render from back to front
+        .map(({ p, i }) => {
+          const depth = i;
+          const isTop = depth === 0;
+          const translateY = depth * 10;
+          const scale = 1 - depth * 0.03;
 
-      <div className="absolute inset-0">
-        {visible
-          .map((p, i) => ({ p, i })) // i: 0=top,1=next,2=third
-          .reverse() // render from back to front so z-index works
-          .map(({ p, i }) => {
-            const depth = i;
-            const isTop = depth === 0;
-            const translateY = depth * 10;
-            const scale = 1 - depth * 0.03;
+          const baseStyle: CSSProperties = {
+            zIndex: 50 - depth,
+            transform: `translateY(${translateY}px) scale(${scale})`,
+            pointerEvents: isTop ? "auto" : "none",
+          };
 
-            const baseStyle: React.CSSProperties = {
-              zIndex: 50 - depth,
-              transform: `translateY(${translateY}px) scale(${scale})`,
-              pointerEvents: isTop ? "auto" : "none",
-            };
-
-            return isTop ? (
-              <AnimatePresence key={p.id} mode="popLayout">
-                <motion.div
-                  className="absolute inset-0 will-change-transform"
-                  style={{ ...baseStyle, x, rotate }}
-                  drag="x"
-                  dragConstraints={{ left: 0, right: 0 }}
-                  dragElastic={0.2}
-                  onDragEnd={onDragEnd}
-                  animate={controls}
-                  initial={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                >
-                  <ProfileCard profile={p} />
-                </motion.div>
-              </AnimatePresence>
-            ) : (
-              <motion.div key={p.id} className="absolute inset-0" style={baseStyle} layout>
+          return isTop ? (
+            <AnimatePresence key={p.id} mode="popLayout">
+              <motion.div
+                className="absolute inset-0"
+                style={{ ...baseStyle, x, rotate }}
+                drag="x"
+                dragConstraints={{ left: 0, right: 0 }}
+                dragElastic={0.2}
+                onDragEnd={onDragEnd}
+                animate={controls}
+                initial={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
                 <ProfileCard profile={p} />
               </motion.div>
-            );
-          })}
-      </div>
+            </AnimatePresence>
+          ) : (
+            <motion.div key={p.id} className="absolute inset-0" style={baseStyle} layout>
+              <ProfileCard profile={p} />
+            </motion.div>
+          );
+        })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Limit feed deck width and add header for centered layout
- Rebuild ProfileCard with responsive next/image and watermark
- Rework SwipeDeck to fixed-height stack with drag controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module 'framer-motion'; type errors in auth.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd03c0a8c08330acd86de916a76fd6