### PR TITLE
feat: simplify swipe deck and card

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -16,7 +16,7 @@ export default function ProfileCard({ profile, onLike, onDislike }: Props) {
 
   return (
     <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-white/5 shadow-2xl backdrop-blur-sm p-3">
-      {/* Foto */}
+      {/* Foto (centered, not full screen) */}
       <div className="relative aspect-[4/5] w-full overflow-hidden rounded-xl">
         <Image
           src={photo}

--- a/src/components/SwipeDeck.tsx
+++ b/src/components/SwipeDeck.tsx
@@ -1,31 +1,29 @@
+// ONE-CARD-ONLY deck with drag gestures.
 "use client";
-import { useMemo, useState } from "react";
-import { motion, useMotionValue, useTransform, AnimatePresence, useAnimationControls } from "framer-motion";
+import { useState } from "react";
+import { motion, useMotionValue, useTransform, useAnimationControls } from "framer-motion";
 import ProfileCard, { type Profile } from "./ProfileCard";
 
 export default function SwipeDeck({ profiles }: { profiles: Profile[] }) {
   const [idx, setIdx] = useState(0);
-  const visible = useMemo(() => profiles.slice(idx, idx + 3), [profiles, idx]);
+  const current = profiles[idx];
 
-  return (
-    // Tinggi area deck cukup lega agar ada margin; kartu akan di-center
-    <div className="relative h-[86vh] w-full">
-      <Stack
-        visible={visible}
-        onAdvance={() => setIdx(i => Math.min(i + 1, profiles.length))}
-      />
-    </div>
-  );
-}
-
-function Stack({ visible, onAdvance }: { visible: Profile[]; onAdvance: () => void }) {
   const controls = useAnimationControls();
   const x = useMotionValue(0);
   const rotate = useTransform(x, [-220, 0, 220], [-15, 0, 15]);
-  const SWIPE_OFFSET = 120;
-  const SWIPE_POWER = 220;
 
-  async function forceSwipe(dir: 1 | -1) {
+  const SWIPE_OFFSET = 120;
+  const SWIPE_POWER  = 220;
+
+  if (!current) {
+    return (
+      <div className="grid place-items-center h-[70vh] text-white/70">
+        No more profiles
+      </div>
+    );
+  }
+
+  async function advance(dir: 1 | -1) {
     await controls.start({
       x: dir * (typeof window === "undefined" ? 800 : window.innerWidth * 1.1),
       rotate: dir * 20,
@@ -33,76 +31,39 @@ function Stack({ visible, onAdvance }: { visible: Profile[]; onAdvance: () => vo
       transition: { duration: 0.25 },
     });
     controls.set({ x: 0, rotate: 0, opacity: 1 });
-    onAdvance();
+    setIdx((i) => Math.min(i + 1, profiles.length));
   }
 
   function onDragEnd(_: any, info: { offset: { x: number }, velocity: { x: number } }) {
     const power = Math.abs(info.offset.x) + Math.abs(info.velocity.x) * 0.2;
     if (power > SWIPE_POWER || Math.abs(info.offset.x) > SWIPE_OFFSET) {
-      forceSwipe(info.offset.x > 0 ? 1 : -1);
+      advance(info.offset.x > 0 ? 1 : -1);
     } else {
       controls.start({ x: 0, rotate: 0, opacity: 1, transition: { type: "spring", stiffness: 380, damping: 28 } });
     }
   }
 
   return (
-    <div className="absolute inset-0">
-      {visible
-        .map((p, i) => ({ p, i }))    // i: 0=top
-        .reverse()
-        .map(({ p, i }) => {
-          const depth = i;
-          const isTop = depth === 0;
-          const translateY = depth * 10;
-          const scale = 1 - depth * 0.03;
-
-          const baseStyle: React.CSSProperties = {
-            zIndex: 50 - depth,
-            pointerEvents: isTop ? "auto" : "none",
-          };
-
-          // Wrapper grid untuk center kartu, memberi margin natural di sekeliling
-          const Center = ({ children }: { children: React.ReactNode }) => (
-            <div
-              className="absolute inset-0 grid place-items-center px-4"
-              style={{
-                ...baseStyle,
-                transform: `translateY(${translateY}px) scale(${scale})`,
-              }}
-            >
-              <div className="w-full max-w-sm">{children}</div>
-            </div>
-          );
-
-          return isTop ? (
-            <AnimatePresence key={p.id} mode="popLayout">
-              <Center>
-                <motion.div
-                  style={{ x, rotate }}
-                  drag="x"
-                  dragConstraints={{ left: 0, right: 0 }}
-                  dragElastic={0.2}
-                  onDragEnd={onDragEnd}
-                  animate={controls}
-                  initial={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                >
-                  <ProfileCard
-                    profile={p}
-                    onLike={() => forceSwipe(1)}
-                    onDislike={() => forceSwipe(-1)}
-                  />
-                </motion.div>
-              </Center>
-            </AnimatePresence>
-          ) : (
-            <Center key={p.id}>
-              <motion.div layout>
-                <ProfileCard profile={p} />
-              </motion.div>
-            </Center>
-          );
-        })}
+    // area deck tinggi cukup + center; hanya 1 kartu
+    <div className="relative h-[82vh] w-full">
+      <div className="absolute inset-0 grid place-items-center px-4">
+        <motion.div
+          className="w-full max-w-sm"
+          style={{ x, rotate }}
+          drag="x"
+          dragConstraints={{ left: 0, right: 0 }}
+          dragElastic={0.2}
+          onDragEnd={onDragEnd}
+          animate={controls}
+          initial={{ opacity: 1 }}
+        >
+          <ProfileCard
+            profile={current}
+            onLike={() => advance(1)}
+            onDislike={() => advance(-1)}
+          />
+        </motion.div>
+      </div>
     </div>
   );
 }

--- a/src/lib/normalizeProfiles.ts
+++ b/src/lib/normalizeProfiles.ts
@@ -2,10 +2,10 @@ import type { Profile } from "@/components/ProfileCard";
 
 export function normalizeProfiles(rows: any[]): Profile[] {
   return rows.map((r: any, i: number) => ({
-    id: r.id?.toString() ?? `u-${i}`,
-    name: r.name ?? r.displayName ?? `User ${i + 1}`,
-    age: r.age ?? 21,
-    gender: r.gender ?? "other",
+    id: String(r.id ?? `u-${i}`),
+    name: r.name ?? r.fullName ?? r.username ?? `User ${i + 1}`,
+    age: r.age ?? r.profile?.age ?? 21,
+    gender: r.gender ?? r.profile?.gender ?? "other",
     photos: Array.isArray(r.photos) && r.photos.length
       ? r.photos
       : [


### PR DESCRIPTION
## Summary
- display profile photo, name and age with like/dislike buttons
- switch swipe deck to single-card view with drag gestures
- normalize profile data to ensure name, age, gender and photo defaults

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'bcryptjs' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3effa1e483308aeda8f5f764e408