### PR TITLE
feat: swipe system with matches, blocks, reports and notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "db:studio": "prisma studio",
     "db:reset": "prisma migrate reset --force",
     "db:push": "prisma db push",
-    "seed": "prisma db seed"
+    "seed": "node prisma/seed.js"
   },
   "dependencies": {
     "@faker-js/faker": "^10.0.0",
@@ -28,7 +28,8 @@
     "react-tinder-card": "^1.6.4",
     "socket.io": "4.7.5",
     "socket.io-client": "4.7.5",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "date-fns": "^3.6.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
@@ -41,8 +42,5 @@
     "tsx": "^4.16.2",
     "typescript": "5.4.2"
   },
-  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
-  }
+  "packageManager": "pnpm@9.15.9"
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,3 +98,12 @@ model Report {
   createdAt DateTime @default(now())
 }
 
+
+model Notification {
+  id        String  @id @default(cuid())
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  type      String
+  entityId  String?
+  createdAt DateTime @default(now())
+}

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,30 @@
+const { PrismaClient } = require("@prisma/client");
+const { faker } = require("@faker-js/faker");
+const prisma = new PrismaClient();
+
+const male = (i) => `https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/male/512/${(i%50)+1}.jpg`;
+const female = (i) => `https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/female/512/${(i%50)+1}.jpg`;
+
+async function main() {
+  for (let i = 0; i < 40; i++) {
+    const isMale = i % 2 === 0;
+    const name = faker.person.fullName();
+    const email = faker.internet.email({ firstName: name.split(" ")[0] }).toLowerCase();
+    const u = await prisma.user.create({
+      data: {
+        email, passwordHash: "dev", name,
+        gender: isMale ? "male" : "female",
+        age: faker.number.int({ min: 21, max: 45 }),
+        photos: { create: [{ url: isMale ? male(i) : female(i), isPrimary: true }] },
+        preferences: {
+          create: {
+            preferredGenders: isMale ? ["female"] : ["male"],
+            minAge: 20, maxAge: 45,
+          },
+        },
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+}
+main().then(()=>prisma.$disconnect()).catch(async (e)=>{console.error(e); await prisma.$disconnect(); process.exit(1);});

--- a/src/app/api/auth/[...nextauth]/options.ts
+++ b/src/app/api/auth/[...nextauth]/options.ts
@@ -1,0 +1,76 @@
+import type { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { prisma } from "@/lib/prisma";
+import bcrypt from "bcryptjs";
+import { z } from "zod";
+
+export const authOptions: NextAuthOptions = {
+  secret: process.env.NEXTAUTH_SECRET,
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        identifier: { label: "Email or Username", type: "text" },
+        password: { label: "Password", type: "password" }
+      },
+      async authorize(credentials) {
+        const schema = z.object({
+          identifier: z.string().min(3),
+          password: z.string().min(6),
+        });
+        const parsed = schema.safeParse(credentials);
+        if (!parsed.success) return null;
+
+        const identifier = parsed.data.identifier.trim().toLowerCase();
+        const pwd = parsed.data.password;
+
+        const where = identifier.includes("@")
+          ? { email: identifier }
+          : { username: identifier };
+
+        const user = await prisma.user.findUnique({
+          where,
+          select: {
+            id: true,
+            email: true,
+            username: true,
+            name: true,
+            passwordHash: true,
+          },
+        });
+        if (!user) return null;
+
+        const valid = await bcrypt.compare(pwd, user.passwordHash);
+        if (!valid) return null;
+
+        return {
+          id: String(user.id),
+          email: user.email,
+          username: user.username,
+          name: user.name ?? null,
+        };
+      },
+    }),
+  ],
+  session: { strategy: "jwt" },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = String(user.id);
+        token.email = user.email;
+        token.username = user.username;
+        token.name = user.name ?? "";
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user && token?.id) {
+        session.user.id = token.id as string;
+        session.user.email = token.email as string;
+        session.user.username = token.username as string | null;
+        session.user.name = token.name as string | null;
+      }
+      return session;
+    },
+  },
+};

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,5 @@
 import NextAuth from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { authOptions } from "./options";
 
 const handler = NextAuth(authOptions);
 

--- a/src/app/api/block/route.ts
+++ b/src/app/api/block/route.ts
@@ -5,9 +5,13 @@ import { requireUser } from "@/lib/auth";
 export async function POST(req: Request) {
   try {
     const me = await requireUser();
-    const { targetId, reason } = await req.json();
+    const { targetId } = await req.json();
     if (!targetId) return NextResponse.json({ error: "targetId required" }, { status: 400 });
-    await prisma.report.create({ data: { byId: me.id, targetId, reason } });
+    await prisma.block.upsert({
+      where: { byId_targetId: { byId: me.id, targetId } },
+      update: {},
+      create: { byId: me.id, targetId },
+    });
     return NextResponse.json({ ok: true });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "ERR" }, { status: 500 });

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireUser } from "@/lib/auth";
+
+export async function GET() {
+  try {
+    const me = await requireUser();
+    const items = await prisma.notification.findMany({
+      where: { userId: me.id },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    });
+    return NextResponse.json({ items });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message ?? "ERR" }, { status: 500 });
+  }
+}

--- a/src/app/api/swipe/route.ts
+++ b/src/app/api/swipe/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireUser } from "@/lib/auth";
+import { startOfDay } from "date-fns";
+
+export async function POST(req: Request) {
+  try {
+    const me = await requireUser();
+    const { targetId, action } = await req.json();
+
+    if (!targetId || !["LIKE", "DISLIKE"].includes(action)) {
+      return NextResponse.json({ error: "Bad request" }, { status: 400 });
+    }
+
+    const today = startOfDay(new Date());
+    const count = await prisma.swipe.count({
+      where: { fromId: me.id, createdAt: { gte: today } },
+    });
+    if (count >= 100) return NextResponse.json({ error: "Daily swipe limit" }, { status: 429 });
+
+    await prisma.user.update({ where: { id: me.id }, data: { lastActiveAt: new Date() } });
+
+    const swipe = await prisma.swipe.upsert({
+      where: { fromId_toId: { fromId: me.id, toId: targetId } },
+      update: { action },
+      create: { fromId: me.id, toId: targetId, action },
+    });
+
+    let matched = false;
+    let matchId: string | undefined;
+
+    if (action === "LIKE") {
+      const theyLiked = await prisma.swipe.findUnique({
+        where: { fromId_toId: { fromId: targetId, toId: me.id } },
+      });
+      if (theyLiked?.action === "LIKE") {
+        const a = me.id < targetId ? me.id : targetId;
+        const b = me.id < targetId ? targetId : me.id;
+
+        const match = await prisma.match.upsert({
+          where: { userAId_userBId: { userAId: a, userBId: b } },
+          update: {},
+          create: { userAId: a, userBId: b },
+        });
+
+        await prisma.notification.createMany({
+          data: [
+            { userId: me.id, type: "MATCH", entityId: match.id },
+            { userId: targetId, type: "MATCH", entityId: match.id },
+          ],
+          skipDuplicates: true,
+        });
+
+        matched = true;
+        matchId = match.id;
+      }
+    }
+
+    return NextResponse.json({ ok: true, matched, matchId, swipe });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message ?? "ERR" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: Request) {
+  try {
+    const me = await requireUser();
+    const { searchParams } = new URL(req.url);
+    const targetId = searchParams.get("targetId");
+    if (!targetId) return NextResponse.json({ error: "targetId required" }, { status: 400 });
+
+    const a = me.id < targetId ? me.id : targetId;
+    const b = me.id < targetId ? targetId : me.id;
+    const alreadyMatched = await prisma.match.findUnique({
+      where: { userAId_userBId: { userAId: a, userBId: b } },
+      select: { id: true },
+    });
+    if (alreadyMatched) return NextResponse.json({ error: "Already matched" }, { status: 409 });
+
+    await prisma.swipe.delete({ where: { fromId_toId: { fromId: me.id, toId: targetId } } });
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message ?? "ERR" }, { status: 500 });
+  }
+}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,82 +1,17 @@
-import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
 import SwipeDeck from "@/components/SwipeDeck";
-import { normalizeProfiles } from "@/lib/normalizeProfiles";
-import type { Profile } from "@/components/ProfileCard";
-
-function getAge(birthdate?: Date | null) {
-  if (!birthdate) return 0;
-  const now = new Date();
-  let age = now.getFullYear() - birthdate.getFullYear();
-  const m = now.getMonth() - birthdate.getMonth();
-  if (m < 0 || (m === 0 && now.getDate() < birthdate.getDate())) age--;
-  return age;
-}
-
-async function getProfiles(userId: number): Promise<Profile[]> {
-  const [likes, hiddens] = await Promise.all([
-    prisma.like.findMany({ where: { fromUser: userId }, select: { toUser: true } }),
-    prisma.hidden.findMany({ where: { userId }, select: { hideId: true } }),
-  ]);
-  const excludeIds = [userId, ...likes.map((l) => l.toUser), ...hiddens.map((h) => h.hideId)];
-
-  const users = await prisma.user.findMany({
-    where: {
-      id: { notIn: excludeIds },
-      name: { not: null },
-      gender: { not: null },
-      birthdate: { not: null },
-    },
-    orderBy: { createdAt: "desc" },
-    take: 20,
-    select: {
-      id: true,
-      name: true,
-      birthdate: true,
-      gender: true,
-      profile: { select: { photos: true } },
-    },
-  });
-
-  const rows = users.map((u) => ({
-    id: u.id,
-    name: u.name!,
-    age: getAge(u.birthdate),
-    gender: u.gender ?? undefined,
-    photos: u.profile?.photos ?? [],
-  }));
-  return normalizeProfiles(rows);
-}
 
 export default async function FeedPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) redirect("/login");
 
-  const userId = Number(session.user.id);
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { name: true, gender: true, birthdate: true },
-  });
-
-  if (!user?.name || !user?.gender || !user?.birthdate) {
-    redirect("/onboarding");
-  }
-
-  const profiles = await getProfiles(userId);
-
   return (
-    <main className="min-h-screen bg-[#0b0f14]">
-      <header className="px-4 pt-4">
-        <h1 className="text-3xl font-bold">Moodmacth</h1>
-      </header>
-
-      <section className="px-4 pt-6 pb-10 flex justify-center">
-        <div className="w-full max-w-2xl">
-          <SwipeDeck profiles={profiles} />
-        </div>
-      </section>
-    </main>
+    <section className="px-4 pt-6 pb-10 flex justify-center">
+      <div className="w-full max-w-2xl">
+        <SwipeDeck />
+      </div>
+    </section>
   );
 }

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,59 +1,27 @@
 import Image from "next/image";
 
-export type Profile = {
-  id: string; name: string; age: number;
-  gender?: string; photos: string[];
-};
+export type Profile = { id: string; name: string; age: number; gender?: string; photo: string };
 
-type Props = {
-  profile: Profile;
-  onLike?: () => void;
-  onDislike?: () => void;
-};
-
-export default function ProfileCard({ profile, onLike, onDislike }: Props) {
-  const photo = profile.photos?.[0] ?? "/placeholder.jpg";
-
+export default function ProfileCard({
+  profile, onLike, onDislike,
+}: { profile: Profile; onLike?: () => void; onDislike?: () => void }) {
   return (
     <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-white/5 shadow-2xl backdrop-blur-sm p-3">
-      {/* Foto (centered, not full screen) */}
       <div className="relative aspect-[4/5] w-full overflow-hidden rounded-xl">
-        <Image
-          src={photo}
-          alt={profile.name}
-          fill
-          sizes="(max-width: 768px) 100vw, 600px"
-          className="object-cover"
-          priority
-        />
+        <Image src={profile.photo} alt={profile.name} fill sizes="(max-width:768px) 100vw, 600px" className="object-cover" />
       </div>
-
-      {/* Info + Actions */}
       <div className="mt-4 flex items-center justify-between gap-3">
         <div className="min-w-0">
           <h3 className="text-xl font-semibold truncate">
             {profile.name}, <span className="text-white/60">{profile.age}</span>
           </h3>
-          {profile.gender && (
-            <p className="text-white/60 text-sm truncate">{profile.gender}</p>
-          )}
+          {profile.gender && <p className="text-white/60 text-sm truncate">{profile.gender}</p>}
         </div>
-
         <div className="flex items-center gap-2">
-          <button
-            aria-label="Dislike"
-            onClick={onDislike}
-            className="h-11 w-11 rounded-full border border-white/15 bg-white/5 hover:bg-white/10 active:scale-95 transition"
-          >
-            ✕
-          </button>
-          <button
-            aria-label="Love"
-            onClick={onLike}
-            className="h-11 w-11 rounded-full border border-white/15 bg-white text-black hover:opacity-90 active:scale-95 transition"
-          >
-            ♥
-          </button>
+          <button aria-label="Dislike" onClick={onDislike}
+            className="h-11 w-11 rounded-full border border-white/15 bg-white/5 hover:bg-white/10 active:scale-95">✕</button>
+          <button aria-label="Love" onClick={onLike}
+            className="h-11 w-11 rounded-full border border-white/15 bg-white text-black hover:opacity-90 active:scale-95">♥</button>
         </div>
       </div>
     </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,76 +1,10 @@
-import type { NextAuthOptions } from "next-auth";
-import CredentialsProvider from "next-auth/providers/credentials";
-import { prisma } from "@/lib/prisma";
-import bcrypt from "bcryptjs";
-import { z } from "zod";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/options";
 
-export const authOptions: NextAuthOptions = {
-  secret: process.env.NEXTAUTH_SECRET,
-  providers: [
-    CredentialsProvider({
-      name: "Credentials",
-      credentials: {
-        identifier: { label: "Email or Username", type: "text" },
-        password: { label: "Password", type: "password" }
-      },
-      async authorize(credentials) {
-        const schema = z.object({
-          identifier: z.string().min(3),
-          password: z.string().min(6),
-        });
-        const parsed = schema.safeParse(credentials);
-        if (!parsed.success) return null;
+export { authOptions };
 
-        const identifier = parsed.data.identifier.trim().toLowerCase();
-        const pwd = parsed.data.password;
-
-        const where = identifier.includes("@")
-          ? { email: identifier }
-          : { username: identifier };
-
-        const user = await prisma.user.findUnique({
-          where,
-          select: {
-            id: true,
-            email: true,
-            username: true,
-            name: true,
-            passwordHash: true,
-          },
-        });
-        if (!user) return null;
-
-        const valid = await bcrypt.compare(pwd, user.passwordHash);
-        if (!valid) return null;
-
-        return {
-          id: String(user.id),
-          email: user.email,
-          username: user.username,
-          name: user.name ?? null,
-        };
-      },
-    }),
-  ],
-  session: { strategy: "jwt" },
-  callbacks: {
-    async jwt({ token, user }) {
-      if (user) {
-        token.id = String(user.id);
-        token.email = user.email;
-        token.username = user.username;
-        token.name = user.name ?? "";
-      }
-      return token;
-    },
-    async session({ session, token }) {
-      if (session.user && token?.id) {
-        session.user.id = token.id as string;
-        session.user.email = token.email as string;
-        session.user.username = token.username as string | null;
-        session.user.name = token.name as string | null;
-      }
-      return session;
-    },
-  },
-};
+export async function requireUser() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) throw new Error("UNAUTHENTICATED");
+  return session.user as { id: string; email?: string | null; name?: string | null };
+}

--- a/src/lib/normalizeProfiles.ts
+++ b/src/lib/normalizeProfiles.ts
@@ -1,17 +1,15 @@
-import type { Profile } from "@/components/ProfileCard";
-
-export function normalizeProfiles(rows: any[]): Profile[] {
-  return rows.map((r: any, i: number) => ({
-    id: String(r.id ?? `u-${i}`),
-    name: r.name ?? r.fullName ?? r.username ?? `User ${i + 1}`,
-    age: r.age ?? r.profile?.age ?? 21,
-    gender: r.gender ?? r.profile?.gender ?? "other",
-    photos: Array.isArray(r.photos) && r.photos.length
-      ? r.photos
-      : [
-          r.avatarUrl ??
-            r.photo ??
-            "https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/male/512/44.jpg",
-        ],
-  }));
+export function normalizeProfile(p: any) {
+  const photo =
+    p.photos?.find?.((x: any) => x.isPrimary)?.url ??
+    p.photos?.[0]?.url ??
+    p.photo ??
+    p.avatarUrl ??
+    "https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/male/512/44.jpg";
+  return {
+    id: String(p.id),
+    name: p.name ?? "User",
+    age: p.age ?? 21,
+    gender: p.gender ?? "other",
+    photo,
+  };
 }


### PR DESCRIPTION
## Summary
- add comprehensive swipe/match schema with notifications
- implement feed/swipe/block/report/notifications APIs and auth helper
- build one-card swipe deck UI with undo and seeding script

## Testing
- `npm i framer-motion @faker-js/faker date-fns` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@faker-js%2ffaker)*
- `npx prisma generate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npx prisma migrate dev -n "swipe_match_pref_block_report_notif"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npm run seed` *(fails: Cannot find module '@prisma/client')*
- `npm run lint` *(fails: next: not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd4ca036b08330adb5cc75c506ecb4