### PR TITLE
Normalize Prisma IDs as numbers

### DIFF
--- a/src/app/api/admin/message/delete/route.ts
+++ b/src/app/api/admin/message/delete/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAdminEmails } from "@/lib/admin";
+import { toIntId } from "@/lib/id";
 
 export async function POST(req: Request) {
   try {
     await requireAdminEmails();
     const fd = await req.formData();
-    const messageId = String(fd.get("messageId") || "");
-    if (!messageId) return NextResponse.json({ error: "Missing messageId" }, { status: 400 });
+    const raw = fd.get("messageId");
+    if (!raw) return NextResponse.json({ error: "Missing messageId" }, { status: 400 });
+    const messageId = toIntId(raw);
 
     await prisma.message.delete({ where: { id: messageId } });
 

--- a/src/app/api/admin/suspend/route.ts
+++ b/src/app/api/admin/suspend/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAdminEmails } from "@/lib/admin";
+import { toIntId } from "@/lib/id";
 
 export async function POST(req: Request) {
   try {
     await requireAdminEmails();
     const fd = await req.formData();
-    const userId = Number(fd.get("userId"));
-    if (!userId) return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+    const raw = fd.get("userId");
+    if (!raw) return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+    const userId = toIntId(raw);
 
     await prisma.profile.deleteMany({ where: { userId } });
 

--- a/src/app/api/admin/unmatch/route.ts
+++ b/src/app/api/admin/unmatch/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAdminEmails } from "@/lib/admin";
+import { toIntId } from "@/lib/id";
 
 export async function POST(req: Request) {
   try {
     await requireAdminEmails();
     const fd = await req.formData();
-    const matchId = String(fd.get("matchId") || "");
-    if (!matchId) return NextResponse.json({ error: "Missing matchId" }, { status: 400 });
+    const raw = fd.get("matchId");
+    if (!raw) return NextResponse.json({ error: "Missing matchId" }, { status: 400 });
+    const matchId = toIntId(raw);
 
     await prisma.message.deleteMany({ where: { matchId } });
     await prisma.match.delete({ where: { id: matchId } });

--- a/src/app/api/admin/unsuspend/route.ts
+++ b/src/app/api/admin/unsuspend/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAdminEmails } from "@/lib/admin";
+import { toIntId } from "@/lib/id";
 
 export async function POST(req: Request) {
   try {
     await requireAdminEmails();
     const fd = await req.formData();
-    const userId = Number(fd.get("userId"));
-    if (!userId) return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+    const raw = fd.get("userId");
+    if (!raw) return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+    const userId = toIntId(raw);
 
     const placeholder = `https://picsum.photos/seed/${String(userId).slice(0,6)}/400/600`;
     await prisma.profile.upsert({

--- a/src/app/api/block/route.ts
+++ b/src/app/api/block/route.ts
@@ -1,16 +1,19 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
+import { toIntId } from "@/lib/id";
 
 export async function POST(req: Request) {
   try {
     const me = await requireUser();
-    const { targetId } = await req.json();
-    if (!targetId) return NextResponse.json({ error: "targetId required" }, { status: 400 });
+    const meId = toIntId(me.id);
+    const { targetId: targetIdRaw } = await req.json();
+    if (!targetIdRaw) return NextResponse.json({ error: "targetId required" }, { status: 400 });
+    const targetId = toIntId(targetIdRaw);
     await prisma.block.upsert({
-      where: { byId_targetId: { byId: me.id, targetId } },
+      where: { byId_targetId: { byId: meId, targetId } },
       update: {},
-      create: { byId: me.id, targetId },
+      create: { byId: meId, targetId },
     });
     return NextResponse.json({ ok: true });
   } catch (e: any) {

--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -2,13 +2,15 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
 import { getIO } from "@/lib/socket";
+import { toIntId } from "@/lib/id";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   try {
     const me = await requireUser();
-    const id = params.id;
+    const meId = toIntId(me.id);
+    const id = toIntId(params.id);
     const conv = await prisma.conversation.findFirst({
-      where: { id, OR: [{ userAId: me.id }, { userBId: me.id }] },
+      where: { id, OR: [{ userAId: meId }, { userBId: meId }] },
     });
     if (!conv) return NextResponse.json({ error: "Not found" }, { status: 404 });
     const items = await prisma.message.findMany({
@@ -25,18 +27,19 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
   try {
     const me = await requireUser();
-    const id = params.id;
+    const meId = toIntId(me.id);
+    const id = toIntId(params.id);
     const { text } = await req.json();
     if (!text) return NextResponse.json({ error: "No text" }, { status: 400 });
     const conv = await prisma.conversation.findFirst({
-      where: { id, OR: [{ userAId: me.id }, { userBId: me.id }] },
+      where: { id, OR: [{ userAId: meId }, { userBId: meId }] },
     });
     if (!conv) return NextResponse.json({ error: "Not found" }, { status: 404 });
     const msg = await prisma.message.create({
-      data: { conversationId: id, senderId: me.id, text },
+      data: { conversationId: id, senderId: meId, text },
     });
     const io = getIO();
-    io?.to(id).emit("message", msg);
+    io?.to(String(id)).emit("message", msg);
     return NextResponse.json(msg);
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "ERR" }, { status: 500 });

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
+import { toIntId } from "@/lib/id";
 
 export async function GET() {
   try {
     const me = await requireUser();
+    const meId = toIntId(me.id);
     const convs = await prisma.conversation.findMany({
-      where: { OR: [{ userAId: me.id }, { userBId: me.id }] },
+      where: { OR: [{ userAId: meId }, { userBId: meId }] },
       orderBy: { createdAt: "desc" },
       include: {
         userA: { select: { id: true, name: true, photos: { where: { isPrimary: true }, take: 1 } } },
@@ -15,7 +17,7 @@ export async function GET() {
       },
     });
     const items = convs.map(c => {
-      const peer = c.userAId === me.id ? c.userB : c.userA;
+      const peer = c.userAId === meId ? c.userB : c.userA;
       const photo = peer.photos[0]?.url || "";
       const lastMessage = c.messages[0] || null;
       return { id: c.id, peer: { id: peer.id, name: peer.name, photo }, lastMessage };

--- a/src/app/api/dislike/route.ts
+++ b/src/app/api/dislike/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
+import { toIntId } from '@/lib/id';
 
 const DislikeSchema = z.object({
   toId: z.number(),
@@ -12,12 +13,11 @@ export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const userId = Number(session.user.id);
+  const userId = toIntId(session.user.id);
   const body = await req.json();
   const parse = DislikeSchema.safeParse(body);
   if (!parse.success) return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
-
-  const { toId } = parse.data;
+  const toId = toIntId(parse.data.toId);
   if (toId === userId) return NextResponse.json({ error: 'Cannot hide yourself' }, { status: 400 });
 
   await prisma.hidden.upsert({

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -3,27 +3,29 @@ import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
 import { normalizeProfile } from "@/lib/normalizeProfiles";
 import { Mood } from "@prisma/client";
+import { toIntId } from "@/lib/id";
 
 export async function GET(req: Request) {
   try {
     const meUser = await requireUser();
-    const me = await prisma.user.findUnique({ where: { id: meUser.id }, select: { id: true, currentMood: true } });
+    const meId = toIntId(meUser.id);
+    const me = await prisma.user.findUnique({ where: { id: meId }, select: { id: true, currentMood: true } });
     if (!me) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
     const { searchParams } = new URL(req.url);
     const moodParam = searchParams.get("mood") as Mood | null;
     const mood = moodParam ?? me.currentMood ?? null;
 
-    const pref = await prisma.preference.findUnique({ where: { userId: me.id } });
+    const pref = await prisma.preference.findUnique({ where: { userId: meId } });
 
-    const swiped = await prisma.swipe.findMany({ where: { fromId: me.id }, select: { toId: true } });
-    const matchedA = await prisma.match.findMany({ where: { userAId: me.id }, select: { userBId: true } });
-    const matchedB = await prisma.match.findMany({ where: { userBId: me.id }, select: { userAId: true } });
-    const blocks1 = await prisma.block.findMany({ where: { byId: me.id }, select: { targetId: true } });
-    const blocks2 = await prisma.block.findMany({ where: { targetId: me.id }, select: { byId: true } });
+    const swiped = await prisma.swipe.findMany({ where: { fromId: meId }, select: { toId: true } });
+    const matchedA = await prisma.match.findMany({ where: { userAId: meId }, select: { userBId: true } });
+    const matchedB = await prisma.match.findMany({ where: { userBId: meId }, select: { userAId: true } });
+    const blocks1 = await prisma.block.findMany({ where: { byId: meId }, select: { targetId: true } });
+    const blocks2 = await prisma.block.findMany({ where: { targetId: meId }, select: { byId: true } });
 
-    const excludeIds = new Set<string>([
-      me.id,
+    const excludeIds = new Set<number>([
+      meId,
       ...swiped.map(s => s.toId),
       ...matchedA.map(m => m.userBId),
       ...matchedB.map(m => m.userAId),

--- a/src/app/api/like/route.ts
+++ b/src/app/api/like/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
+import { toIntId } from '@/lib/id';
 
 const LikeSchema = z.object({
   toId: z.number(),
@@ -12,12 +13,11 @@ export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const userId = Number(session.user.id);
+  const userId = toIntId(session.user.id);
   const body = await req.json();
   const parse = LikeSchema.safeParse(body);
   if (!parse.success) return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
-
-  const { toId } = parse.data;
+  const toId = toIntId(parse.data.toId);
   if (toId === userId) return NextResponse.json({ error: 'Cannot like yourself' }, { status: 400 });
 
   await prisma.like.create({

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
 import { log } from "@/lib/logger";
+import { toIntId } from "@/lib/id";
 
 const EditableSchema = z.object({
   name: z.string().min(1).optional(),
@@ -20,8 +21,10 @@ export async function GET(req: NextRequest) {
     log("GET /api/me: Unauthorized");
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const userId = Number(session.user.id);
-  if (Number.isNaN(userId)) {
+  let userId: number;
+  try {
+    userId = toIntId(session.user.id);
+  } catch {
     log("GET /api/me: Bad user id", session.user.id);
     return NextResponse.json({ error: "Bad user id" }, { status: 400 });
   }
@@ -42,8 +45,10 @@ export async function PATCH(req: NextRequest) {
     log("PATCH /api/me: Unauthorized");
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const userId = Number(session.user.id);
-  if (Number.isNaN(userId)) {
+  let userId: number;
+  try {
+    userId = toIntId(session.user.id);
+  } catch {
     log("PATCH /api/me: Bad user id", session.user.id);
     return NextResponse.json({ error: "Bad user id" }, { status: 400 });
   }

--- a/src/app/api/mood/route.ts
+++ b/src/app/api/mood/route.ts
@@ -2,16 +2,18 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
 import { Mood } from "@prisma/client";
+import { toIntId } from "@/lib/id";
 
 export async function PATCH(req: Request) {
   try {
     const me = await requireUser();
+    const meId = toIntId(me.id);
     const { mood } = await req.json();
     if (!mood || !(Object.values(Mood) as string[]).includes(mood)) {
       return NextResponse.json({ error: "Bad mood" }, { status: 400 });
     }
     await prisma.user.update({
-      where: { id: me.id },
+      where: { id: meId },
       data: { currentMood: mood as Mood },
     });
     return NextResponse.json({ ok: true });

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
+import { toIntId } from "@/lib/id";
 
 export async function GET() {
   try {
     const me = await requireUser();
+    const meId = toIntId(me.id);
     const items = await prisma.notification.findMany({
-      where: { userId: me.id },
+      where: { userId: meId },
       orderBy: { createdAt: "desc" },
       take: 20,
     });

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,14 +1,16 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
+import { toIntId } from "@/lib/id";
 
 export async function PATCH(req: Request) {
   try {
     const me = await requireUser();
+    const meId = toIntId(me.id);
     const { gender, birthYear, photo } = await req.json();
     const age = birthYear ? new Date().getFullYear() - Number(birthYear) : undefined;
     await prisma.user.update({
-      where: { id: me.id },
+      where: { id: meId },
       data: {
         gender: gender || undefined,
         age,

--- a/src/app/api/report/route.ts
+++ b/src/app/api/report/route.ts
@@ -1,13 +1,16 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
+import { toIntId } from "@/lib/id";
 
 export async function POST(req: Request) {
   try {
     const me = await requireUser();
-    const { targetId, reason } = await req.json();
-    if (!targetId) return NextResponse.json({ error: "targetId required" }, { status: 400 });
-    await prisma.report.create({ data: { byId: me.id, targetId, reason } });
+    const meId = toIntId(me.id);
+    const { targetId: targetIdRaw, reason } = await req.json();
+    if (!targetIdRaw) return NextResponse.json({ error: "targetId required" }, { status: 400 });
+    const targetId = toIntId(targetIdRaw);
+    await prisma.report.create({ data: { byId: meId, targetId, reason } });
     return NextResponse.json({ ok: true });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "ERR" }, { status: 500 });

--- a/src/app/api/swipe/route.ts
+++ b/src/app/api/swipe/route.ts
@@ -2,28 +2,30 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
 import { startOfDay } from "date-fns";
+import { toIntId } from "@/lib/id";
 
 export async function POST(req: Request) {
   try {
     const me = await requireUser();
-    const { targetId, action } = await req.json();
-
-    if (!targetId || !["LIKE", "DISLIKE"].includes(action)) {
+    const meId = toIntId(me.id);
+    const { targetId: targetIdRaw, action } = await req.json();
+    if (!targetIdRaw || !["LIKE", "DISLIKE"].includes(action)) {
       return NextResponse.json({ error: "Bad request" }, { status: 400 });
     }
+    const targetId = toIntId(targetIdRaw);
 
     const today = startOfDay(new Date());
     const count = await prisma.swipe.count({
-      where: { fromId: me.id, createdAt: { gte: today } },
+      where: { fromId: meId, createdAt: { gte: today } },
     });
     if (count >= 100) return NextResponse.json({ error: "Daily swipe limit" }, { status: 429 });
 
-    await prisma.user.update({ where: { id: me.id }, data: { lastActiveAt: new Date() } });
+    await prisma.user.update({ where: { id: meId }, data: { lastActiveAt: new Date() } });
 
     const swipe = await prisma.swipe.upsert({
-      where: { fromId_toId: { fromId: me.id, toId: targetId } },
+      where: { fromId_toId: { fromId: meId, toId: targetId } },
       update: { action },
-      create: { fromId: me.id, toId: targetId, action },
+      create: { fromId: meId, toId: targetId, action },
     });
 
     let matched = false;
@@ -32,11 +34,11 @@ export async function POST(req: Request) {
 
     if (action === "LIKE") {
       const theyLiked = await prisma.swipe.findUnique({
-        where: { fromId_toId: { fromId: targetId, toId: me.id } },
+        where: { fromId_toId: { fromId: targetId, toId: meId } },
       });
       if (theyLiked?.action === "LIKE") {
-        const a = me.id < targetId ? me.id : targetId;
-        const b = me.id < targetId ? targetId : me.id;
+        const a = meId < targetId ? meId : targetId;
+        const b = meId < targetId ? targetId : meId;
 
         const [match, conversation] = await prisma.$transaction([
           prisma.match.upsert({
@@ -53,7 +55,7 @@ export async function POST(req: Request) {
 
         await prisma.notification.createMany({
           data: [
-            { userId: me.id, type: "MATCH", entityId: match.id },
+            { userId: meId, type: "MATCH", entityId: match.id },
             { userId: targetId, type: "MATCH", entityId: match.id },
           ],
           skipDuplicates: true,
@@ -74,19 +76,21 @@ export async function POST(req: Request) {
 export async function DELETE(req: Request) {
   try {
     const me = await requireUser();
+    const meId = toIntId(me.id);
     const { searchParams } = new URL(req.url);
-    const targetId = searchParams.get("targetId");
-    if (!targetId) return NextResponse.json({ error: "targetId required" }, { status: 400 });
+    const targetIdParam = searchParams.get("targetId");
+    if (!targetIdParam) return NextResponse.json({ error: "targetId required" }, { status: 400 });
+    const targetId = toIntId(targetIdParam);
 
-    const a = me.id < targetId ? me.id : targetId;
-    const b = me.id < targetId ? targetId : me.id;
+    const a = meId < targetId ? meId : targetId;
+    const b = meId < targetId ? targetId : meId;
     const alreadyMatched = await prisma.match.findUnique({
       where: { userAId_userBId: { userAId: a, userBId: b } },
       select: { id: true },
     });
     if (alreadyMatched) return NextResponse.json({ error: "Already matched" }, { status: 409 });
 
-    await prisma.swipe.delete({ where: { fromId_toId: { fromId: me.id, toId: targetId } } });
+    await prisma.swipe.delete({ where: { fromId_toId: { fromId: meId, toId: targetId } } });
     return NextResponse.json({ ok: true });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "ERR" }, { status: 500 });

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -2,13 +2,14 @@
 import { useEffect, useState, useRef } from "react";
 import { useSocket } from "@/lib/useSocket";
 import { useSession } from "next-auth/react";
+import { toIntId } from "@/lib/id";
 
 export default function Page({ params }: { params: { id: string } }) {
-  const { id } = params;
+  const id = toIntId(params.id);
   const { data: session } = useSession();
   const [messages, setMessages] = useState<any[]>([]);
   const [text, setText] = useState("");
-  const socketRef = useSocket(id);
+  const socketRef = useSocket(String(id));
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -45,7 +46,7 @@ export default function Page({ params }: { params: { id: string } }) {
     setText("");
   }
 
-  const meId = session?.user?.id;
+  const meId = session?.user?.id ? toIntId(session.user.id) : undefined;
 
   return (
     <div className="flex flex-col h-screen">

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -3,11 +3,12 @@ import { redirect } from "next/navigation";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import SwipeDeck from "@/components/SwipeDeck";
+import { toIntId } from "@/lib/id";
 
 export default async function FeedPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) redirect("/login");
-  const me = await prisma.user.findUnique({ where: { id: session.user.id as string }, select: { currentMood: true } });
+  const me = await prisma.user.findUnique({ where: { id: toIntId(session.user.id) }, select: { currentMood: true } });
   if (!me?.currentMood) redirect("/mood");
 
   return (

--- a/src/app/match/page.tsx
+++ b/src/app/match/page.tsx
@@ -1,11 +1,13 @@
 import { prisma } from "@/lib/prisma";
 import { requireUser } from "@/lib/auth";
 import Link from "next/link";
+import { toIntId } from "@/lib/id";
 
 export default async function MatchPage() {
   const me = await requireUser();
+  const meId = toIntId(me.id);
   const convs = await prisma.conversation.findMany({
-    where: { OR: [{ userAId: me.id }, { userBId: me.id }] },
+    where: { OR: [{ userAId: meId }, { userBId: meId }] },
     orderBy: { createdAt: "desc" },
     include: {
       userA: { select: { id: true, name: true, photos: { where: { isPrimary: true }, take: 1 } } },
@@ -14,7 +16,7 @@ export default async function MatchPage() {
     },
   });
   const items = convs.map(c => {
-    const peer = c.userAId === me.id ? c.userB : c.userA;
+    const peer = c.userAId === meId ? c.userB : c.userA;
     const photo = peer.photos[0]?.url || "";
     const lastMessage = c.messages[0]?.text || "";
     return { id: c.id, peer: { id: peer.id, name: peer.name, photo }, lastMessage };

--- a/src/lib/id.ts
+++ b/src/lib/id.ts
@@ -1,0 +1,5 @@
+export function toIntId(v: unknown): number {
+  const n = typeof v === "string" ? Number(v) : (v as number);
+  if (!Number.isInteger(n)) throw new Error("Invalid Int ID");
+  return n;
+}


### PR DESCRIPTION
## Summary
- add `toIntId` helper to validate and convert IDs to integers
- refactor pages, API routes, and socket handler to supply numeric IDs to Prisma

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bd64a22dfc83309025fe554e78b789