### PR TITLE
Derive user mood from latest session

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model User {
   age          Int?
   photos       Photo[]
   preferences  Preference?
-  currentMood  Mood?
+  moodSessions MoodSession[]
   swipesMade   Swipe[]   @relation("swipes_made")
   swipesRecv   Swipe[]   @relation("swipes_recv")
   matchesA     Match[]   @relation("matches_a")
@@ -40,6 +40,7 @@ model User {
   conversationsA Conversation[] @relation("conv_a")
   conversationsB Conversation[] @relation("conv_b")
   messages       Message[]
+  notifications Notification[]
   lastActiveAt DateTime? @db.Timestamp(6)
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
@@ -139,4 +140,12 @@ model Message {
   senderId      String
   text          String
   createdAt     DateTime     @default(now())
+}
+
+model MoodSession {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  mood      Mood
+  createdAt DateTime @default(now())
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -10,6 +10,7 @@ async function main() {
     const isMale = i % 2 === 0;
     const name = faker.person.fullName();
     const email = faker.internet.email({ firstName: name.split(" ")[0] }).toLowerCase();
+    const mood = faker.helpers.arrayElement(["NORMAL","SERIOUS","FUN","HOT"]);
     await prisma.user.create({
       data: {
         email,
@@ -17,7 +18,6 @@ async function main() {
         name,
         gender: isMale ? "male" : "female",
         age: faker.number.int({ min: 21, max: 45 }),
-        currentMood: faker.helpers.arrayElement(["NORMAL","SERIOUS","FUN","HOT"]),
         photos: { create: [{ url: isMale ? male(i) : female(i), isPrimary: true }] },
         preferences: {
           create: {
@@ -27,6 +27,7 @@ async function main() {
           },
         },
         lastActiveAt: new Date(),
+        moodSessions: { create: { mood, createdAt: new Date() } },
       },
     });
   }

--- a/src/app/api/mood/route.ts
+++ b/src/app/api/mood/route.ts
@@ -4,17 +4,15 @@ import { requireUser } from "@/lib/auth";
 import { Mood } from "@prisma/client";
 import { toIntId } from "@/lib/id";
 
-export async function PATCH(req: Request) {
+export async function POST(req: Request) {
   try {
     const me = await requireUser();
-    const meId = toIntId(me.id);
     const { mood } = await req.json();
     if (!mood || !(Object.values(Mood) as string[]).includes(mood)) {
-      return NextResponse.json({ error: "Bad mood" }, { status: 400 });
+      return NextResponse.json({ error: "mood required" }, { status: 400 });
     }
-    await prisma.user.update({
-      where: { id: meId },
-      data: { currentMood: mood as Mood },
+    await prisma.moodSession.create({
+      data: { userId: toIntId(me.id), mood, createdAt: new Date() },
     });
     return NextResponse.json({ ok: true });
   } catch (e: any) {

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,20 +1,20 @@
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { authOptions } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
 import SwipeDeck from "@/components/SwipeDeck";
-import { toIntId } from "@/lib/id";
+import { getCurrentMood } from "@/lib/mood";
 
 export default async function FeedPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) redirect("/login");
-  const me = await prisma.user.findUnique({ where: { id: toIntId(session.user.id) }, select: { currentMood: true } });
-  if (!me?.currentMood) redirect("/mood");
+
+  const mood = await getCurrentMood(session.user.id);
+  if (!mood) redirect("/mood");
 
   return (
     <section className="px-4 pt-6 pb-10 flex justify-center">
       <div className="w-full max-w-2xl">
-        <SwipeDeck mood={me.currentMood} />
+        <SwipeDeck mood={mood} />
       </div>
     </section>
   );

--- a/src/app/mood/page.tsx
+++ b/src/app/mood/page.tsx
@@ -7,11 +7,11 @@ export default function MoodPage() {
   const router = useRouter();
   async function pick(mood: string) {
     await fetch("/api/mood", {
-      method: "PATCH",
+      method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ mood }),
     });
-    router.push("/feed");
+    router.push(`/feed?mood=${encodeURIComponent(mood)}`);
   }
 
   return (

--- a/src/lib/mood.ts
+++ b/src/lib/mood.ts
@@ -1,0 +1,12 @@
+import { prisma } from "@/lib/prisma";
+import { toIntId } from "@/lib/id";
+
+export async function getCurrentMood(userId: string | number) {
+  const id = toIntId(userId);
+  const last = await prisma.moodSession.findFirst({
+    where: { userId: id },
+    orderBy: { createdAt: "desc" },
+    select: { mood: true },
+  });
+  return last?.mood ?? null;
+}


### PR DESCRIPTION
## Summary
- derive current mood from latest MoodSession
- update feed page and API routes to use helper and remove User.currentMood
- create mood sessions on mood API and seed script; add MoodSession model

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Type 'number' is not assignable to type 'string' in various modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bd685484208330befd81c044e40dcc