### PR TITLE
Compute age from birthdate in API responses

### DIFF
--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -8,12 +8,12 @@ export async function PATCH(req: Request) {
     const me = await requireUser();
     const meId = toIntId(me.id);
     const { gender, birthYear, photo } = await req.json();
-    const age = birthYear ? new Date().getFullYear() - Number(birthYear) : undefined;
+    const birthdate = birthYear ? new Date(Number(birthYear), 0, 1) : undefined;
     await prisma.user.update({
       where: { id: meId },
       data: {
         gender: gender || undefined,
-        age,
+        birthdate,
         photos: photo
           ? {
               create: { url: photo, isPrimary: true },

--- a/src/lib/age.ts
+++ b/src/lib/age.ts
@@ -1,0 +1,10 @@
+export function calcAge(birthdate?: string | Date | null): number | null {
+  if (!birthdate) return null;
+  const d = new Date(birthdate);
+  if (Number.isNaN(d.getTime())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - d.getFullYear();
+  const m = now.getMonth() - d.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < d.getDate())) age--;
+  return age;
+}

--- a/src/lib/normalizeProfiles.ts
+++ b/src/lib/normalizeProfiles.ts
@@ -1,3 +1,5 @@
+import { calcAge } from "./age";
+
 export function normalizeProfile(p: any) {
   const photo =
     p.photos?.find?.((x: any) => x.isPrimary)?.url ??
@@ -8,7 +10,7 @@ export function normalizeProfile(p: any) {
   return {
     id: String(p.id),
     name: p.name ?? "User",
-    age: p.age ?? 21,
+    age: calcAge(p.birthdate) ?? p.age ?? 21,
     gender: p.gender ?? "other",
     photo,
   };


### PR DESCRIPTION
## Summary
- add calcAge helper for deriving age from a birthdate
- update feed API to fetch birthdate and return computed age
- store birthdate during onboarding and normalize profiles with calcAge

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck` *(fails: TS errors in existing sources)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7ae5b75083308f082a3c02842ea0